### PR TITLE
added /resolves-within endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This service returns a list (in JSON) of geologic time intervals that intersect 
 
 example:
 
-``curl "127.0.0.1:5000/resolve?min=1000&max=1200"``
+``curl "127.0.0.1:5000/resolve-intersects?min=1000&max=1200"``
 
 results:
 
@@ -12,81 +12,81 @@ results:
 [  
    {  
       "pid":0,
-      "eag":2500,
-      "rid":[  
-         47900
-      ],
-      "oid":752,
+      "lag":541,
       "typ":"int",
-      "nam":"Proterozoic",
-      "lvl":1,
       "col":"#F73563",
-      "lag":541
-   },
-   {  
-      "pid":752,
-      "eag":1600,
+      "eag":2500,
+      "nam":"Proterozoic",
       "rid":[  
          47900
       ],
-      "oid":755,
-      "typ":"int",
-      "nam":"Mesoproterozoic",
-      "lvl":2,
-      "col":"#FDB462",
-      "lag":1000
+      "lvl":1,
+      "oid":752
    },
    {  
       "pid":752,
-      "eag":1000,
-      "rid":[  
-         47900
-      ],
-      "oid":754,
+      "lag":541,
       "typ":"int",
-      "nam":"Neoproterozoic",
-      "lvl":2,
       "col":"#FEB342",
-      "lag":541
-   },
-   {  
-      "pid":755,
-      "eag":1400,
+      "eag":1000,
+      "nam":"Neoproterozoic",
       "rid":[  
          47900
       ],
-      "oid":765,
-      "typ":"int",
-      "nam":"Ectasian",
-      "lvl":3,
-      "col":"#F3CC8A",
-      "lag":1200
+      "lvl":2,
+      "oid":754
    },
    {  
-      "pid":755,
-      "eag":1200,
+      "pid":752,
+      "lag":1000,
+      "typ":"int",
+      "col":"#FDB462",
+      "eag":1600,
+      "nam":"Mesoproterozoic",
       "rid":[  
          47900
       ],
-      "oid":764,
-      "typ":"int",
-      "nam":"Stenian",
-      "lvl":3,
-      "col":"#FED99A",
-      "lag":1000
+      "lvl":2,
+      "oid":755
    },
    {  
       "pid":754,
+      "lag":850,
+      "typ":"int",
+      "col":"#FEBF4E",
       "eag":1000,
+      "nam":"Tonian",
       "rid":[  
          47900
       ],
-      "oid":763,
-      "typ":"int",
-      "nam":"Tonian",
       "lvl":3,
-      "col":"#FEBF4E",
-      "lag":850
+      "oid":763
+   },
+   {  
+      "pid":755,
+      "lag":1000,
+      "typ":"int",
+      "col":"#FED99A",
+      "eag":1200,
+      "nam":"Stenian",
+      "rid":[  
+         47900
+      ],
+      "lvl":3,
+      "oid":764
+   },
+   {  
+      "pid":755,
+      "lag":1200,
+      "typ":"int",
+      "col":"#F3CC8A",
+      "eag":1400,
+      "nam":"Ectasian",
+      "rid":[  
+         47900
+      ],
+      "lvl":3,
+      "oid":765
    }
 ]
 ```

--- a/app.py
+++ b/app.py
@@ -41,8 +41,8 @@ def hello():
 
 
 def process_inputs():
-    min_age = float(request.args.get('min', ''))
-    max_age = float(request.args.get('max', ''))
+    min_age = request.args.get('min', None, type=float)
+    max_age = request.args.get('max', None, type=float)
 
     if min_age is None or max_age is None:
         abort(400)

--- a/app.py
+++ b/app.py
@@ -40,25 +40,25 @@ def hello():
     return json.dumps(data)
 
 
-@app.route("/resolve-within", methods=['GET'])
-def encompassed():
+def process_inputs():
     min_age = float(request.args.get('min', ''))
     max_age = float(request.args.get('max', ''))
 
     if min_age is None or max_age is None:
         abort(400)
 
+    return min_age, max_age
+
+
+@app.route("/resolve-within", methods=['GET'])
+def resolve_within():
+    min_age, max_age = process_inputs()
     return resolve_geologic_time_within(min_age, max_age)
 
 
 @app.route("/resolve-intersects", methods=['GET'])
-def geo():
-    min_age = float(request.args.get('min', ''))
-    max_age = float(request.args.get('max', ''))
-
-    if min_age is None or max_age is None:
-        abort(400)
-
+def resolve_intersects():
+    min_age, max_age = process_inputs()
     return resolve_geologic_time_intersects(min_age, max_age)
 
 


### PR DESCRIPTION
- [ x ] added `/resolves-within` endpoint which returns lowest level geologic time interval that the specified min and max times fall within
- [ x ]  fixed bug in results sorting
