### PR TITLE
Fixes to handle cases where /resolve-within does not find a result

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,6 +31,10 @@ def within(interval, min_age, max_age):
 
 def resolve_geologic_time_within(min_age, max_age):
     z = [interval for interval in data["records"] if within(interval, min_age, max_age)]
+
+    if not z:
+        return z
+
     z.sort(key=lambda x: x["lvl"], reverse=True)
     return json.dumps(z[0])
 

--- a/test_app.py
+++ b/test_app.py
@@ -1,0 +1,29 @@
+import unittest
+import app
+
+
+class TestGeologicTimeResolver(unittest.TestCase):
+
+    def test_hello(self):
+        hello = app.hello()
+        self.assertIsNotNone(hello)
+
+    def test_resolve_within(self):
+        out = app.resolve_geologic_time_within(0, 100)
+        self.assertIsNotNone(out)
+
+    def test_resolve_intersects(self):
+        out = app.resolve_geologic_time_intersects(0, 100)
+        self.assertIsNotNone(out)
+
+    def test_extreme_resolves_within(self):
+        out = app.resolve_geologic_time_within(5400, 5600)
+        self.assertIsNotNone(out)
+
+    def test_resolves_within_with_no_higher_concept(self):
+        out = app.resolve_geologic_time_within(540, 542)
+        self.assertIsNotNone(out)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
updates:
- [x] `resolve_geologic_time_within` now checks for and returns empty set in cases where no interval falls within the specified min/max.  
- [x] added unit test suite.

Fixes #2 Fixes #3
